### PR TITLE
Set type: module in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "ThreeJS loader for 4dviews volumetric video format",
   "main": "src/three-volumetric-4dviews.js",
+  "type": "module",
   "directories": {
     "example": "examples",
     "lib": "lib"


### PR DESCRIPTION
Hi!
Adding `"type": "module"` to `package.json` [instructs Node applications](https://nodejs.org/docs/latest-v12.x/api/packages.html#packages_type) to load the package as an ES-Module. It is now supported by default since [Node 10 reached its end of life](https://blog.sindresorhus.com/hello-modules-d1010b4e777b).
This makes it easier to write test applications that use `three-volumetric-4dviews` as pure ES Modules. Especially useful since three.js [switched to native ES6 modules in r127](https://github.com/mrdoob/three.js/issues/19986#issuecomment-813554361), and cannot be loaded into node without some serious transpilation. Three.JS also uses `"type": "module"`, for example [here](https://github.com/mrdoob/three.js/blob/dev/examples/jsm/package.json#L2).
Thank you!
/Avner